### PR TITLE
Provide path from overwrite

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ runs:
         shell: bash
       - run: wget https://cs.symfony.com/download/php-cs-fixer-v3.phar
         shell: bash
-      - run: PHP_CS_FIXER_IGNORE_ENV=1  php php-cs-fixer-v3.phar fix --config=.style/.php-cs-fixer.php -v --dry-run --allow-risky=yes .
+      - run: PHP_CS_FIXER_IGNORE_ENV=1  php php-cs-fixer-v3.phar fix --config=.style/.php-cs-fixer.php -v --dry-run --allow-risky=yes
         shell: bash
       - run: |
           if [[ -f ".style/json-check.php" ]]; then


### PR DESCRIPTION
Der Punkt am Ende des Befehls überschreibt scheinbar die Konfiguration aus dem Finder. 

Quelle: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/2956#issuecomment-319713451